### PR TITLE
+ Azure Stream Analytics Job. IP eventhub & OP SA

### DIFF
--- a/streamanalytics_job/servian-london-tweets/Inputs/LondonTwitterStream.json
+++ b/streamanalytics_job/servian-london-tweets/Inputs/LondonTwitterStream.json
@@ -1,0 +1,18 @@
+{
+    "Name": "LondonTwitterStream",
+    "Type": "Data Stream",
+    "DataSourceType": "Event Hub",
+    "EventHubProperties": {
+        "SharedAccessPolicyKey": null,
+        "ConsumerGroupName": "$Default"
+    },
+    "PartitionKey": null,
+    "DataSourceCredentialDomain": null,
+    "Serialization": {
+        "Type": "Json",
+        "Encoding": "UTF8",
+        "FieldDelimiter": null
+    },
+    "CompressionType": "GZip",
+    "ScriptType": "Input"
+}

--- a/streamanalytics_job/servian-london-tweets/JobConfig.json
+++ b/streamanalytics_job/servian-london-tweets/JobConfig.json
@@ -1,0 +1,23 @@
+{
+    "Tags": {},
+    "DataLocale": "en-US",
+    "OutputErrorPolicy": "Retry",
+    "EventsLateArrivalMaxDelayInSeconds": 5,
+    "EventsOutOfOrderMaxDelayInSeconds": 0,
+    "EventsOutOfOrderPolicy": "Adjust",
+    "ScriptType": "JobConfig",
+    "CompatibilityLevel": "1.2",
+    "UseSystemAssignedIdentity": false,
+    "GlobalStorage": {
+        "AccountName": null,
+        "AccountKey": null
+    },
+    "CustomCodeStorage": {
+        "AccountName": null,
+        "AccountKey": null,
+        "ContainerName": null,
+        "Path": null
+    },
+    "DataSourceCredentialDomain": null,
+    "StreamingUnits": 3
+}

--- a/streamanalytics_job/servian-london-tweets/Outputs/landing.json
+++ b/streamanalytics_job/servian-london-tweets/Outputs/landing.json
@@ -1,0 +1,25 @@
+{
+    "Name": "landing",
+    "DataSourceType": "Blob Storage",
+    "BlobStorageProperties": {
+        "StorageAccounts": [
+            {
+                "AccountName": "serviantweetstreaming",
+                "AccountKey": null
+            }
+        ],
+        "Container": "landing",
+        "PathPattern": "",
+        "DateFormat": "yyyy/MM/dd",
+        "TimeFormat": "HH",
+        "AuthenticationMode": "ConnectionString"
+    },
+    "DataSourceCredentialDomain": "bb4c212c-b17a-4278-8bfe-3c065d0bd156.StreamAnalystics",
+    "Serialization": {
+        "Type": "Json",
+        "Encoding": "UTF8",
+        "Format": "LineSeparated",
+        "FieldDelimiter": null
+    },
+    "ScriptType": "Output"
+}

--- a/streamanalytics_job/servian-london-tweets/Transformation.asaql
+++ b/streamanalytics_job/servian-london-tweets/Transformation.asaql
@@ -1,0 +1,2 @@
+SELECT text, created_at, retweet_count, favorite_count, quote_count, lang
+FROM LondonTwitterStream

--- a/streamanalytics_job/servian-london-tweets/asaproj.json
+++ b/streamanalytics_job/servian-london-tweets/asaproj.json
@@ -1,0 +1,18 @@
+{
+    "name": "servian-london-tweets",
+    "startFile": "Transformation.asaql",
+    "configurations": [
+        {
+            "filePath": "JobConfig.json",
+            "subType": "JobConfig"
+        },
+        {
+            "filePath": "Inputs/LondonTwitterStream.json",
+            "subType": "Input"
+        },
+        {
+            "filePath": "Outputs/landing.json",
+            "subType": "Output"
+        }
+    ]
+}


### PR DESCRIPTION
Added the Azure Stream Analytics Job.
The Job reads tweets from the Event Hub Entity created in the Event Hub Namespace "tweet-servian" and runs in the Stream Analytics Job "servian-london-tweets". The output for batch based processing is in Storage Account "BLOB Storage".